### PR TITLE
Add GitHub Copilot Review Setup workflow

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -38,24 +38,24 @@ jobs:
                 issue_number: prNumber,
                 body: `## 🤖 GitHub Copilot Code Review Setup
                 
-**Note:** GitHub Copilot cannot be requested as a reviewer programmatically. To enable automatic Copilot reviews for this repository:
+            **Note:** GitHub Copilot cannot be requested as a reviewer programmatically. To enable automatic Copilot reviews for this repository:
 
-### Option 1: Configure Repository Rules (Recommended)
-1. Go to **Settings** → **Rules** → **Rulesets**
-2. Create a new branch ruleset
-3. Under "Branch rules," select **Require a pull request before merging**
-4. Enable **Request pull request review from Copilot**
+            ### Option 1: Configure Repository Rules (Recommended)
+            1. Go to **Settings** → **Rules** → **Rulesets**
+            2. Create a new branch ruleset
+            3. Under "Branch rules," select **Require a pull request before merging**
+            4. Enable **Request pull request review from Copilot**
 
-### Option 2: Manual Review Request
-- Click the **Reviewers** section in this PR
-- Select **Copilot** from the dropdown menu
+            ### Option 2: Manual Review Request
+            - Click the **Reviewers** section in this PR
+            - Select **Copilot** from the dropdown menu
 
-### Requirements
-- Copilot Pro or Copilot Pro+ subscription for individual repos
-- Repository or organization owner access for configuration
+            ### Requirements
+            - Copilot Pro or Copilot Pro+ subscription for individual repos
+            - Repository or organization owner access for configuration
 
-Once configured, Copilot will automatically review all new PRs (not drafts).
+            Once configured, Copilot will automatically review all new PRs (not drafts).
 
-[Learn more about Copilot code review](https://docs.github.com/en/copilot/using-github-copilot/code-review/configuring-automatic-code-review-by-copilot)`
+            [Learn more about Copilot code review](https://docs.github.com/en/copilot/using-github-copilot/code-review/configuring-automatic-code-review-by-copilot)`
               });
             }

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -37,3 +37,25 @@ jobs:
                 repo,
                 issue_number: prNumber,
                 body: `## 🤖 GitHub Copilot Code Review Setup
+                
+**Note:** GitHub Copilot cannot be requested as a reviewer programmatically. To enable automatic Copilot reviews for this repository:
+
+### Option 1: Configure Repository Rules (Recommended)
+1. Go to **Settings** → **Rules** → **Rulesets**
+2. Create a new branch ruleset
+3. Under "Branch rules," select **Require a pull request before merging**
+4. Enable **Request pull request review from Copilot**
+
+### Option 2: Manual Review Request
+- Click the **Reviewers** section in this PR
+- Select **Copilot** from the dropdown menu
+
+### Requirements
+- Copilot Pro or Copilot Pro+ subscription for individual repos
+- Repository or organization owner access for configuration
+
+Once configured, Copilot will automatically review all new PRs (not drafts).
+
+[Learn more about Copilot code review](https://docs.github.com/en/copilot/using-github-copilot/code-review/configuring-automatic-code-review-by-copilot)`
+              });
+            }

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,39 @@
+name: Copilot Review Setup Guide
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  copilot-review-info:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - name: Add Copilot Review Instructions
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.COPILOT_REVIEW }}
+          script: |
+            const prNumber = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            
+            // Check if this is the first comment to avoid spamming
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber
+            });
+            
+            const hasCopilotComment = comments.data.some(comment => 
+              comment.body.includes('GitHub Copilot Code Review Setup')
+            );
+            
+            if (!hasCopilotComment) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: `## 🤖 GitHub Copilot Code Review Setup


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically add Copilot review instructions to pull requests when they are opened. The workflow ensures that comments are not duplicated by checking existing comments on the pull request.

### New GitHub Actions Workflow:

* [`.github/workflows/copilot-review.yml`](diffhunk://#diff-3b2e39c35eced7bb2cd13e283dc5a19683bbbb8a5ef43897790bffb05b02e1e4R1-R39): Added a workflow named "Copilot Review Setup Guide" triggered on `pull_request` events of type `opened`. It includes a job (`copilot-review-info`) that uses `actions/github-script` to add a comment with Copilot review instructions, ensuring no duplicate comments are added by checking existing comments.